### PR TITLE
Call open before setting responseType

### DIFF
--- a/tga.js
+++ b/tga.js
@@ -361,8 +361,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 	{
 		var req, tga = this;
 		req = new XMLHttpRequest();
-		req.responseType = 'arraybuffer';
 		req.open('GET', path, true);
+		req.responseType = 'arraybuffer';
 		req.onload = function() {
 			if (this.status === 200) {
 				tga.load(new Uint8Array(req.response));


### PR DESCRIPTION
Currently tga.js is not working on Firefox.
http://gyazo.com/b12642e11869ffa761adeaa9d9dfb571
We need to call xhr.open before setting xhr.responseType.
See: 4.7.7 http://www.w3.org/TR/2011/WD-XMLHttpRequest2-20110816/
