### PR TITLE
Fix broken open()

### DIFF
--- a/src/tga.js
+++ b/src/tga.js
@@ -379,7 +379,7 @@ export default class TgaLoader {
     req.responseType = 'arraybuffer';
     req.open('GET', path, true);
     req.onload = () => {
-      if (this.status === 200) {
+      if (req.status === 200) {
         this.load(new Uint8Array(req.response));
         if (callback) {
           callback();


### PR DESCRIPTION
Hi! I think you missed this while refactoring the project - 4f736a5.

#### Issue
`TgaLoader.open()` always fails.

#### Why
`this` was not replaced with `req` when the function was changed to an arrow function.

Thanks for the library BTW!